### PR TITLE
[Fix] Ignore all magic mismatches

### DIFF
--- a/kernel/module.c
+++ b/kernel/module.c
@@ -3663,6 +3663,9 @@ static int load_module(struct load_info *info, const char __user *uargs,
 	long err;
 	char *after_dashes;
 
+	flags |= MODULE_INIT_IGNORE_MODVERSIONS;
+	flags |= MODULE_INIT_IGNORE_VERMAGIC;
+
 	err = module_sig_check(info, flags);
 	if (err)
 		goto free_copy;


### PR DESCRIPTION
Fix it by adding.
	flags |= MODULE_INIT_IGNORE_MODVERSIONS;
	flags |= MODULE_INIT_IGNORE_VERMAGIC;
in `load_module`  method